### PR TITLE
fix: refresh PR/CI data along with diff on updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
           setPrComments([]);
         }
       })
-      .catch(() => {});
+      .catch((e) => console.error(new Error("Failed to fetch PR", { cause: e })));
   }, []);
 
   useEffect(() => {
@@ -91,7 +91,7 @@ export default function App() {
 
   const refreshAll = useCallback(() => {
     refresh();
-    api.getStatus().then((s) => setBranch(s.branch)).catch((e) => console.error("Failed to fetch branch status", { cause: e }));
+    api.getStatus().then((s) => setBranch(s.branch)).catch((e) => console.error(new Error("Failed to fetch branch status", { cause: e })));
     fetchPR();
   }, [refresh, fetchPR]);
 


### PR DESCRIPTION
## Summary

When a diff update occurs (via WebSocket or manual refresh), only the diff and branch status were refreshed — PR state, CI checks, and review comments were not. This PR extracts PR/CI fetching into a reusable `fetchPR` callback and introduces `refreshAll` to ensure all data is re-fetched together.

## Changes

- Extract `PR` type to a named type alias
- Create `fetchPR` callback that fetches PR info, CI checks, and review comments
- Create `refreshAll` callback combining `refresh()`, branch status fetch, and `fetchPR()`
- Use `refreshAll` in WebSocket handler, Toolbar `onRefresh`, and DiffView `onRefresh`
- Reset checks/comments to empty arrays when no PR exists (prevents stale data)

## Breaking Changes

None

## Test Plan

- Open cmux-hub with a repo that has an associated PR
- Verify PR state, CI checks, and review comments load on initial page load
- Make a commit or file change and confirm all data refreshes (not just the diff)
- Click the refresh button in the toolbar and confirm PR/CI data updates
- Test with a repo that has no PR and verify no errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
