### PR TITLE
fix: use gh pr list instead of gh pr view to distinguish no-PR from API errors

### DIFF
--- a/server/__tests__/github.test.ts
+++ b/server/__tests__/github.test.ts
@@ -13,7 +13,7 @@ function createFakeRunner(responses: Record<string, string>): CommandRunner {
 }
 
 describe("createGitHubService", () => {
-  test("getCurrentPR parses JSON response", async () => {
+  test("getCurrentPR parses JSON response from gh pr list", async () => {
     const prData = {
       number: 42,
       title: "My PR",
@@ -24,32 +24,33 @@ describe("createGitHubService", () => {
       body: "Description",
     };
     const runner = createFakeRunner({
-      "pr view --json": JSON.stringify(prData),
+      "pr list --head": JSON.stringify([prData]),
     });
     const gh = createGitHubService(runner, "/tmp/test");
-    const pr = await gh.getCurrentPR();
+    const pr = await gh.getCurrentPR("feature/x");
     expect(pr).toEqual(prData);
   });
 
-  test("getCurrentPR returns null when no PR", async () => {
-    const runner: CommandRunner = async () => {
-      throw new Error("no PR found");
-    };
+  test("getCurrentPR returns null when no PR exists (empty array)", async () => {
+    // gh pr list returns empty array with exit code 0 when no PR exists
+    const runner = createFakeRunner({
+      "pr list --head": JSON.stringify([]),
+    });
     const gh = createGitHubService(runner, "/tmp/test");
-    const pr = await gh.getCurrentPR();
+    const pr = await gh.getCurrentPR("no-pr-branch");
     expect(pr).toBeNull();
   });
 
-  test("getCIChecks parses response", async () => {
-    const prData = {
-      number: 1,
-      title: "PR",
-      state: "OPEN",
-      url: "",
-      headRefName: "feat",
-      baseRefName: "main",
-      body: "",
+  test("getCurrentPR throws on API errors", async () => {
+    // gh pr list returns exit code 1 on real API errors (network, auth)
+    const runner: CommandRunner = async () => {
+      throw new Error("Command failed: gh pr list\nHTTP 500");
     };
+    const gh = createGitHubService(runner, "/tmp/test");
+    await expect(gh.getCurrentPR("some-branch")).rejects.toThrow("HTTP 500");
+  });
+
+  test("getCIChecks parses response", async () => {
     const graphqlResponse = {
       data: {
         repository: {
@@ -79,12 +80,11 @@ describe("createGitHubService", () => {
       },
     };
     const runner = createFakeRunner({
-      "pr view --json": JSON.stringify(prData),
       "repo view --json": JSON.stringify({ owner: { login: "test" }, name: "repo" }),
       "api graphql": JSON.stringify(graphqlResponse),
     });
     const gh = createGitHubService(runner, "/tmp/test");
-    const checks = await gh.getCIChecks();
+    const checks = await gh.getCIChecks({ prNumber: 1 });
     expect(checks).toEqual([
       { name: "ci", status: "COMPLETED", conclusion: "SUCCESS", url: "https://example.com" },
     ]);
@@ -95,7 +95,7 @@ describe("createGitHubService", () => {
       throw new Error("no checks");
     };
     const gh = createGitHubService(runner, "/tmp/test");
-    const checks = await gh.getCIChecks();
+    const checks = await gh.getCIChecks({ prNumber: 1 });
     expect(checks).toEqual([]);
   });
 
@@ -103,7 +103,7 @@ describe("createGitHubService", () => {
     let capturedCwd: string | undefined;
     const runner: CommandRunner = async (cmd, options) => {
       capturedCwd = options?.cwd;
-      return JSON.stringify({
+      return JSON.stringify([{
         number: 1,
         title: "",
         state: "",
@@ -111,10 +111,10 @@ describe("createGitHubService", () => {
         headRefName: "",
         baseRefName: "",
         body: "",
-      });
+      }]);
     };
     const gh = createGitHubService(runner, "/my/project");
-    await gh.getCurrentPR();
+    await gh.getCurrentPR("main");
     expect(capturedCwd).toBe("/my/project");
   });
 });

--- a/server/__tests__/integration.test.ts
+++ b/server/__tests__/integration.test.ts
@@ -38,8 +38,8 @@ function createFakeRunner(): { runner: CommandRunner; calls: string[][] } {
     if (key.includes("diff --name-only")) return "src/index.ts\n";
     if (key.includes("branch -a")) return "main\nfeature/test\n";
     if (key.includes("status --porcelain")) return "M src/index.ts\n";
-    if (key.includes("gh pr view"))
-      return JSON.stringify({
+    if (key.includes("gh pr list"))
+      return JSON.stringify([{
         number: 42,
         title: "Test PR",
         state: "OPEN",
@@ -47,7 +47,7 @@ function createFakeRunner(): { runner: CommandRunner; calls: string[][] } {
         headRefName: "feature/test",
         baseRefName: "main",
         body: "PR body",
-      });
+      }]);
     if (key.includes("gh repo view"))
       return JSON.stringify({ owner: { login: "test" }, name: "repo" });
     if (key.includes("gh api graphql") && key.includes("reviewThreads"))

--- a/server/__tests__/poll-github.test.ts
+++ b/server/__tests__/poll-github.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, describe } from "bun:test";
+import assert from "node:assert";
+import { createAppConfig } from "../app.ts";
+import { createGitService, type CommandRunner } from "../git.ts";
+import { createCmuxService, createDryRunConnector } from "../cmux.ts";
+import { createGitHubService } from "../github.ts";
+
+const PORT = 14599;
+
+function validHeaders(): Record<string, string> {
+  return { host: `127.0.0.1:${PORT}` };
+}
+
+const PR_DATA = {
+  number: 42,
+  title: "Test PR",
+  state: "OPEN",
+  url: "https://github.com/test/repo/pull/42",
+  headRefName: "feature/test",
+  baseRefName: "main",
+  body: "PR body",
+};
+
+function createTestApp(ghRunner: CommandRunner) {
+  const baseRunner: CommandRunner = async (cmd) => {
+    const key = cmd.join(" ");
+    if (key === "git rev-parse HEAD") return "abc123\n";
+    if (key.includes("rev-parse --abbrev-ref HEAD")) return "feature/test\n";
+    if (key.includes("symbolic-ref")) return "origin/main\n";
+    if (key.includes("merge-base")) return "abc123\n";
+    if (key.includes("diff")) return "";
+    if (key.includes("branch -a")) return "main\n";
+    if (key.includes("status --porcelain")) return "";
+    // Delegate gh commands to ghRunner
+    if (key.startsWith("gh ")) return ghRunner(cmd);
+    throw new Error(`Unexpected command: ${key}`);
+  };
+
+  const git = createGitService(baseRunner, "/tmp/test");
+  const cmux = createCmuxService(createDryRunConnector());
+  const github = createGitHubService(ghRunner, "/tmp/test");
+
+  return createAppConfig({ port: PORT, git, cmux, github, cwd: "/tmp/test" });
+}
+
+async function getPR(app: ReturnType<typeof createAppConfig>) {
+  const handler = (app.apiRoutes["/api/pr"] as { GET: (req: Request) => Response }).GET;
+  const res = handler(new Request(`http://127.0.0.1:${PORT}/api/pr`, { headers: validHeaders() }));
+  return (await res.json()) as { pr: typeof PR_DATA | null };
+}
+
+async function getCI(app: ReturnType<typeof createAppConfig>) {
+  const handler = (app.apiRoutes["/api/ci"] as { GET: (req: Request) => Response }).GET;
+  const res = handler(new Request(`http://127.0.0.1:${PORT}/api/ci`, { headers: validHeaders() }));
+  return (await res.json()) as { checks: unknown[] };
+}
+
+describe("pollGitHub cache behavior", () => {
+  test("API error preserves cached PR data", async () => {
+    let shouldFail = false;
+    const ghRunner: CommandRunner = async (cmd) => {
+      const key = cmd.join(" ");
+      if (key.includes("gh pr list")) {
+        if (shouldFail) throw new Error("HTTP 500");
+        return JSON.stringify([PR_DATA]);
+      }
+      if (key.includes("gh repo view"))
+        return JSON.stringify({ owner: { login: "test" }, name: "repo" });
+      if (key.includes("gh api graphql"))
+        return JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: { nodes: [{ commit: { statusCheckRollup: { contexts: { nodes: [] } } } }] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        });
+      throw new Error(`Unexpected gh command: ${key}`);
+    };
+
+    const app = createTestApp(ghRunner);
+
+    // First poll: PR exists
+    await app.pollGitHub();
+    const before = await getPR(app);
+    assert(before.pr !== null);
+    expect(before.pr.number).toBe(42);
+
+    // Second poll: API error — cached data should be preserved
+    shouldFail = true;
+    await app.pollGitHub();
+    const after = await getPR(app);
+    assert(after.pr !== null);
+    expect(after.pr.number).toBe(42);
+  });
+
+  test("no PR clears cached data", async () => {
+    let hasPR = true;
+    const ghRunner: CommandRunner = async (cmd) => {
+      const key = cmd.join(" ");
+      if (key.includes("gh pr list")) {
+        return hasPR ? JSON.stringify([PR_DATA]) : JSON.stringify([]);
+      }
+      if (key.includes("gh repo view"))
+        return JSON.stringify({ owner: { login: "test" }, name: "repo" });
+      if (key.includes("gh api graphql"))
+        return JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: { nodes: [{ commit: { statusCheckRollup: { contexts: { nodes: [{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS", detailsUrl: "" }] } } } }] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        });
+      throw new Error(`Unexpected gh command: ${key}`);
+    };
+
+    const app = createTestApp(ghRunner);
+
+    // First poll: PR exists with CI checks
+    await app.pollGitHub();
+    const before = await getPR(app);
+    const ciBefore = await getCI(app);
+    expect(before.pr).not.toBeNull();
+    expect(ciBefore.checks).toHaveLength(1);
+
+    // Second poll: PR no longer exists — cache should be cleared
+    hasPR = false;
+    await app.pollGitHub();
+    const after = await getPR(app);
+    const ciAfter = await getCI(app);
+    expect(after.pr).toBeNull();
+    expect(ciAfter.checks).toHaveLength(0);
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -29,7 +29,7 @@ type AppDeps = {
   actions?: MenuItem[];
   watcher?: {
     start(): void;
-    onChanged(cb: () => void): void;
+    onChanged(cb: (event: { hasRefChange: boolean }) => void): void;
     stop(): void;
   };
 };
@@ -87,12 +87,30 @@ export function createAppConfig(deps: AppDeps) {
   let pollTimer: ReturnType<typeof setInterval> | null = null;
 
   async function pollGitHub() {
+    let pr: Awaited<ReturnType<typeof github.getCurrentPR>>;
     try {
-      const pr = await github.getCurrentPR();
-      cachedPR = pr;
-      if (!pr) return;
+      const branch = await git.getCurrentBranch();
+      pr = await github.getCurrentPR(branch);
+    } catch {
+      // API error (network, auth, etc.) — keep cached values, skip update
+      return;
+    }
+    cachedPR = pr;
+    if (!pr) {
+      cachedChecks = [];
+      cachedComments = [];
+      const message = JSON.stringify({
+        type: "pr-updated",
+        data: { pr: null, checks: [], comments: [] },
+      });
+      for (const ws of wsClients.keys()) {
+        ws.send(message);
+      }
+      return;
+    }
+    try {
       const [checks, comments] = await Promise.all([
-        github.getCIChecks(),
+        github.getCIChecks({ prNumber: pr.number }),
         github.getPRComments(pr.number),
       ]);
       cachedChecks = checks;
@@ -105,7 +123,7 @@ export function createAppConfig(deps: AppDeps) {
         ws.send(message);
       }
     } catch {
-      // ignore polling errors
+      // CI/comments fetch error — keep PR info but don't update checks/comments
     }
   }
 
@@ -507,10 +525,14 @@ export function createAppConfig(deps: AppDeps) {
     startWatcher() {
       if (deps.watcher) {
         deps.watcher.start();
-        deps.watcher.onChanged(() => {
+        deps.watcher.onChanged((event) => {
           const message = JSON.stringify({ type: "diff-updated" });
           for (const ws of wsClients.keys()) {
             ws.send(message);
+          }
+          // On ref changes (push, fetch, branch switch), poll GitHub immediately
+          if (event.hasRefChange) {
+            pollGitHub();
           }
         });
       }

--- a/server/github.ts
+++ b/server/github.ts
@@ -34,18 +34,26 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
   const gh = (args: string[]) => run(["gh", ...args], { cwd });
 
   return {
-    async getCurrentPR(): Promise<PRInfo | null> {
-      try {
-        const raw = await gh([
-          "pr",
-          "view",
-          "--json",
-          "number,title,state,url,headRefName,baseRefName,body",
-        ]);
-        return JSON.parse(raw);
-      } catch {
-        return null;
-      }
+    // Use `gh pr list` instead of `gh pr view` to distinguish "no PR" from API errors.
+    // `gh pr view` returns exit code 1 for both cases, making them indistinguishable.
+    // `gh pr list` returns exit code 0 with empty array when no PR exists,
+    // and exit code 1 only on real API errors (network, auth).
+    // ref: https://github.com/cli/cli — `gh pr view` vs `gh pr list` exit code behavior
+    async getCurrentPR(branch: string): Promise<PRInfo | null> {
+      const raw = await gh([
+        "pr",
+        "list",
+        "--head",
+        branch,
+        "--state",
+        "all",
+        "--json",
+        "number,title,state,url,headRefName,baseRefName,body",
+        "--limit",
+        "1",
+      ]);
+      const results: PRInfo[] = JSON.parse(raw);
+      return results.length > 0 ? results[0] : null;
     },
 
     async getPRComments(prNumber: number): Promise<PRComment[]> {
@@ -152,10 +160,8 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
       }
     },
 
-    async getCIChecks(): Promise<CICheck[]> {
+    async getCIChecks({ prNumber }: { prNumber: number }): Promise<CICheck[]> {
       try {
-        const pr = await this.getCurrentPR();
-        if (!pr) return [];
         const repoRaw = await gh(["repo", "view", "--json", "owner,name"]);
         const repo = JSON.parse(repoRaw) as { owner: { login: string }; name: string };
         const query = `query($owner: String!, $name: String!, $number: Int!) {
@@ -192,7 +198,7 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
           "-F",
           `name=${repo.name}`,
           "-F",
-          `number=${pr.number}`,
+          `number=${prNumber}`,
         ]);
         const data = JSON.parse(raw);
         const nodes =

--- a/server/watcher.ts
+++ b/server/watcher.ts
@@ -55,20 +55,31 @@ export const defaultWatcherFactory: WatcherFactory = (dir, callback) => {
 
 export type FileWatcher = ReturnType<typeof createFileWatcher>;
 
+export type ChangeEvent = {
+  hasRefChange: boolean;
+};
+export type ChangeListener = (event: ChangeEvent) => void;
+
 export function createFileWatcher(factory: WatcherFactory, cwd: string) {
   let watcher: { close: () => void } | null = null;
-  const listeners = new Set<() => void>();
+  const listeners = new Set<ChangeListener>();
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingRefChange = false;
 
   return {
     start() {
       if (watcher) return;
-      watcher = factory(cwd, (_event, _filename) => {
+      watcher = factory(cwd, (_event, filename) => {
+        if (filename && (filename.includes("refs/") || filename.endsWith("HEAD"))) {
+          pendingRefChange = true;
+        }
         // Debounce notifications
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
+          const event: ChangeEvent = { hasRefChange: pendingRefChange };
+          pendingRefChange = false;
           for (const listener of listeners) {
-            listener();
+            listener(event);
           }
         }, 300);
       });
@@ -85,7 +96,7 @@ export function createFileWatcher(factory: WatcherFactory, cwd: string) {
       }
     },
 
-    onChanged(listener: () => void) {
+    onChanged(listener: ChangeListener) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },


### PR DESCRIPTION
…PI errors

`gh pr view` returns exit code 1 for both "no PR exists" and real API errors, making them indistinguishable. Switch to `gh pr list --head <branch>` which returns exit code 0 with empty array when no PR exists, reserving exit code 1 for actual errors.

Also:
- Pass branch name to getCurrentPR() and prNumber to getCIChecks()
- Detect git ref changes in watcher to trigger immediate GitHub polling
- Preserve cached PR data on API errors instead of silently clearing
- Clear cache properly when PR is genuinely removed