### PR TITLE
fix: enlarge file-level comment button for better clickability

### DIFF
--- a/src/components/DiffFile.tsx
+++ b/src/components/DiffFile.tsx
@@ -287,7 +287,7 @@ export function DiffFile({ file, onComment, prComments = [] }: Props) {
         <span className="text-[#adbac7] font-mono text-sm flex-1">{file.newPath}</span>
         {onComment && (
           <button
-            className="text-[#848d97] hover:text-[#58a6ff] text-xs px-2 py-0.5 rounded hover:bg-[#30363d] transition-colors"
+            className="text-[#848d97] hover:text-[#58a6ff] text-sm px-4 py-1.5 rounded hover:bg-[#30363d] transition-colors"
             onClick={(e) => {
               e.stopPropagation();
               setShowFileComment((v) => !v);


### PR DESCRIPTION
## Summary

Increases the padding and font size of the file-level comment button in the diff file header. The previous button was too small (`text-xs px-2 py-0.5`), making it difficult to click. Updated to `text-sm px-4 py-1.5` for a larger, more accessible click target.

## Changes

- Increased font size from `text-xs` to `text-sm`
- Increased horizontal padding from `px-2` to `px-4`
- Increased vertical padding from `py-0.5` to `py-1.5`

## Breaking Changes

None

## Test Plan

- Open cmux-hub diff view with a file that has changes
- Verify the file-level comment button (💬) in the file header is visibly larger
- Confirm the button is easier to click and hover state still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)