### PR TITLE
feat: render PR comments as Markdown

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -15,6 +15,7 @@ type PRInfo = {
 type PRComment = {
   id: number;
   body: string;
+  bodyHtml: string;
   user: string;
   path: string;
   line: number;
@@ -67,6 +68,7 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
                   nodes {
                     databaseId
                     body
+                    bodyHTML
                     author { login }
                     path
                     line
@@ -103,6 +105,7 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
                     nodes: Array<{
                       databaseId: number;
                       body: string;
+                      bodyHTML: string;
                       author: { login: string };
                       path: string;
                       line: number;
@@ -123,6 +126,7 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
           comments.push({
             id: c.databaseId,
             body: c.body,
+            bodyHtml: c.bodyHTML,
             user: c.author.login,
             path: c.path,
             line: c.line,

--- a/src/components/DiffFile.tsx
+++ b/src/components/DiffFile.tsx
@@ -8,6 +8,7 @@ import { api } from "../lib/api.ts";
 type PRCommentData = {
   id: number;
   body: string;
+  bodyHtml: string;
   user: string;
   path: string;
   line: number;

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -8,6 +8,7 @@ import { api } from "../lib/api.ts";
 type PRComment = {
   id: number;
   body: string;
+  bodyHtml: string;
   user: string;
   path: string;
   line: number;

--- a/src/components/PRComments.tsx
+++ b/src/components/PRComments.tsx
@@ -4,6 +4,7 @@ import { api } from "../lib/api.ts";
 type Comment = {
   id: number;
   body: string;
+  bodyHtml: string;
   user: string;
   path: string;
   line: number;
@@ -34,7 +35,10 @@ export function InlinePRComment({ comment, filePath }: Props) {
     <div className="flex items-start gap-2 py-1 text-sm">
       <div className="flex-1 min-w-0">
         <span className="text-[#58a6ff] font-medium">@{comment.user}</span>
-        <span className="text-[#848d97] ml-2 whitespace-pre-wrap break-words">{comment.body}</span>
+        <div
+          className="text-[#848d97] ml-2 markdown-body"
+          dangerouslySetInnerHTML={{ __html: comment.bodyHtml }}
+        />
       </div>
       <button
         onClick={handleSend}

--- a/src/hooks/usePRData.ts
+++ b/src/hooks/usePRData.ts
@@ -18,6 +18,7 @@ type Check = {
 type PRComment = {
   id: number;
   body: string;
+  bodyHtml: string;
   user: string;
   path: string;
   line: number;

--- a/src/index.css
+++ b/src/index.css
@@ -34,3 +34,85 @@
 .animate-progress-bar {
   animation: progress-bar 1s ease-in-out infinite;
 }
+
+.markdown-body {
+  word-break: break-word;
+}
+
+.markdown-body p {
+  margin: 0.25em 0;
+}
+
+.markdown-body code {
+  background-color: #343942;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: ui-monospace, monospace;
+}
+
+.markdown-body pre {
+  background-color: #161b22;
+  padding: 0.75em;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+}
+
+.markdown-body pre code {
+  background-color: transparent;
+  padding: 0;
+  font-size: 0.85em;
+}
+
+.markdown-body a {
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body blockquote {
+  border-left: 3px solid #30363d;
+  padding-left: 0.75em;
+  margin: 0.5em 0;
+  color: #848d97;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 1.5em;
+  margin: 0.25em 0;
+}
+
+.markdown-body strong {
+  color: #e6edf3;
+}
+
+.markdown-body img {
+  max-width: 100%;
+  border-radius: 6px;
+}
+
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid #30363d;
+  margin: 0.5em 0;
+}
+
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+}
+
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid #30363d;
+  padding: 0.25em 0.5em;
+}
+
+.markdown-body del {
+  color: #6e7681;
+}


### PR DESCRIPTION
## Summary

Render PR review comments as Markdown instead of plain text by using the `bodyHTML` field from the GitHub GraphQL API.

## Changes

- Fetch `bodyHTML` alongside `body` from the GitHub GraphQL API for PR review comments
- Add `bodyHtml` field to the `PRComment` type across all components and hooks
- Replace plain-text comment rendering with `dangerouslySetInnerHTML` using the GitHub-rendered HTML
- Add `.markdown-body` CSS styles for code blocks, links, blockquotes, lists, tables, images, and other Markdown elements

## Breaking Changes

None

## Test Plan

- Open a PR with Markdown-formatted review comments (code blocks, links, bold, lists, etc.)
- Verify comments render with proper formatting instead of raw Markdown syntax
- Confirm inline code, fenced code blocks, links, and blockquotes display correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/azu/cmux-hub/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
