### PR TITLE
fix: migrate getCurrentPR to REST API with ETag caching and reduce poll interval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,14 @@ Localhost-only server (`127.0.0.1`). Key defenses against browser-based attacks 
   `/api/review/delete` (write) guard caller-supplied paths via
   `isPathInsideReviewDirs` to prevent escape out of the configured set.
 
+## GitHub API Rate Limit
+
+`gh api --cache <duration>` を使ってREST APIのETag/条件付きリクエストを活用する。304応答はrate limitにカウントされない。`gh pr list`等の高レベルコマンドは`--cache`非対応なので、rate limitが問題になるエンドポイントは`gh api repos/...`のREST APIに切り替える。
+
+- `getCurrentPR`: `gh api repos/{owner}/{repo}/pulls --cache 30s`
+- owner/repo解決（`gh repo view`）はセッション内でキャッシュ（変わらないため）
+- REST APIのstate（小文字`open`/`closed`）はフロント用に大文字`OPEN`/`CLOSED`/`MERGED`に正規化。`merged`はstateではなく`merged_at`で判定
+
 ## HMR
 
 `bun --hot` re-executes top-level code. Use `globalThis` to persist state across reloads (e.g. browser surface ref to avoid opening duplicate windows).

--- a/server/__tests__/github.test.ts
+++ b/server/__tests__/github.test.ts
@@ -12,9 +12,27 @@ function createFakeRunner(responses: Record<string, string>): CommandRunner {
   };
 }
 
+const REPO_VIEW = JSON.stringify({ owner: { login: "test" }, name: "repo" });
+
 describe("createGitHubService", () => {
-  test("getCurrentPR parses JSON response from gh pr list", async () => {
-    const prData = {
+  test("getCurrentPR parses REST API response and normalizes state", async () => {
+    const restPR = {
+      number: 42,
+      title: "My PR",
+      state: "open",
+      merged_at: null,
+      html_url: "https://github.com/test/repo/pull/42",
+      head: { ref: "feature/x" },
+      base: { ref: "main" },
+      body: "Description",
+    };
+    const runner = createFakeRunner({
+      "repo view --json": REPO_VIEW,
+      "gh api repos/": JSON.stringify([restPR]),
+    });
+    const gh = createGitHubService(runner, "/tmp/test");
+    const pr = await gh.getCurrentPR("feature/x");
+    expect(pr).toEqual({
       number: 42,
       title: "My PR",
       state: "OPEN",
@@ -22,19 +40,53 @@ describe("createGitHubService", () => {
       headRefName: "feature/x",
       baseRefName: "main",
       body: "Description",
+    });
+  });
+
+  test("getCurrentPR returns MERGED state when merged_at is set", async () => {
+    const restPR = {
+      number: 10,
+      title: "Merged PR",
+      state: "closed",
+      merged_at: "2024-01-01T00:00:00Z",
+      html_url: "https://github.com/test/repo/pull/10",
+      head: { ref: "feature/merged" },
+      base: { ref: "main" },
+      body: "",
     };
     const runner = createFakeRunner({
-      "pr list --head": JSON.stringify([prData]),
+      "repo view --json": REPO_VIEW,
+      "gh api repos/": JSON.stringify([restPR]),
     });
     const gh = createGitHubService(runner, "/tmp/test");
-    const pr = await gh.getCurrentPR("feature/x");
-    expect(pr).toEqual(prData);
+    const pr = await gh.getCurrentPR("feature/merged");
+    expect(pr?.state).toBe("MERGED");
+  });
+
+  test("getCurrentPR returns CLOSED state for closed non-merged PR", async () => {
+    const restPR = {
+      number: 11,
+      title: "Closed PR",
+      state: "closed",
+      merged_at: null,
+      html_url: "https://github.com/test/repo/pull/11",
+      head: { ref: "feature/closed" },
+      base: { ref: "main" },
+      body: "",
+    };
+    const runner = createFakeRunner({
+      "repo view --json": REPO_VIEW,
+      "gh api repos/": JSON.stringify([restPR]),
+    });
+    const gh = createGitHubService(runner, "/tmp/test");
+    const pr = await gh.getCurrentPR("feature/closed");
+    expect(pr?.state).toBe("CLOSED");
   });
 
   test("getCurrentPR returns null when no PR exists (empty array)", async () => {
-    // gh pr list returns empty array with exit code 0 when no PR exists
     const runner = createFakeRunner({
-      "pr list --head": JSON.stringify([]),
+      "repo view --json": REPO_VIEW,
+      "gh api repos/": JSON.stringify([]),
     });
     const gh = createGitHubService(runner, "/tmp/test");
     const pr = await gh.getCurrentPR("no-pr-branch");
@@ -42,9 +94,10 @@ describe("createGitHubService", () => {
   });
 
   test("getCurrentPR throws on API errors", async () => {
-    // gh pr list returns exit code 1 on real API errors (network, auth)
-    const runner: CommandRunner = async () => {
-      throw new Error("Command failed: gh pr list\nHTTP 500");
+    const runner: CommandRunner = async (cmd) => {
+      const key = cmd.join(" ");
+      if (key.includes("repo view --json")) return REPO_VIEW;
+      throw new Error("HTTP 500");
     };
     const gh = createGitHubService(runner, "/tmp/test");
     await expect(gh.getCurrentPR("some-branch")).rejects.toThrow("HTTP 500");
@@ -80,7 +133,7 @@ describe("createGitHubService", () => {
       },
     };
     const runner = createFakeRunner({
-      "repo view --json": JSON.stringify({ owner: { login: "test" }, name: "repo" }),
+      "repo view --json": REPO_VIEW,
       "api graphql": JSON.stringify(graphqlResponse),
     });
     const gh = createGitHubService(runner, "/tmp/test");
@@ -102,14 +155,17 @@ describe("createGitHubService", () => {
     let capturedCwd: string | undefined;
     const runner: CommandRunner = async (cmd, options) => {
       capturedCwd = options?.cwd;
+      const key = cmd.join(" ");
+      if (key.includes("repo view --json")) return REPO_VIEW;
       return JSON.stringify([
         {
           number: 1,
           title: "",
-          state: "",
-          url: "",
-          headRefName: "",
-          baseRefName: "",
+          state: "open",
+          merged_at: null,
+          html_url: "",
+          head: { ref: "" },
+          base: { ref: "" },
           body: "",
         },
       ]);
@@ -117,5 +173,22 @@ describe("createGitHubService", () => {
     const gh = createGitHubService(runner, "/my/project");
     await gh.getCurrentPR("main");
     expect(capturedCwd).toBe("/my/project");
+  });
+
+  test("caches owner/repo across calls", async () => {
+    let repoViewCalls = 0;
+    const runner: CommandRunner = async (cmd) => {
+      const key = cmd.join(" ");
+      if (key.includes("repo view --json")) {
+        repoViewCalls++;
+        return REPO_VIEW;
+      }
+      if (key.includes("gh api repos/")) return JSON.stringify([]);
+      throw new Error(`Unexpected command: ${key}`);
+    };
+    const gh = createGitHubService(runner, "/tmp/test");
+    await gh.getCurrentPR("branch-1");
+    await gh.getCurrentPR("branch-2");
+    expect(repoViewCalls).toBe(1);
   });
 });

--- a/server/__tests__/integration.test.ts
+++ b/server/__tests__/integration.test.ts
@@ -11,7 +11,7 @@ index abc1234..def5678 100644
 +++ b/src/index.ts
 @@ -1,3 +1,4 @@
  import { serve } from "bun";
-+import { newModule } from "./new";
++import { addedModule } from "./new";
 
  const server = serve({`;
 
@@ -38,15 +38,16 @@ function createFakeRunner(): { runner: CommandRunner; calls: string[][] } {
     if (key.includes("diff --name-only")) return "src/index.ts\n";
     if (key.includes("branch -a")) return "main\nfeature/test\n";
     if (key.includes("status --porcelain")) return "M src/index.ts\n";
-    if (key.includes("gh pr list"))
+    if (key.includes("gh api repos/") && key.includes("/pulls") && !key.includes("reviews"))
       return JSON.stringify([
         {
           number: 42,
           title: "Test PR",
-          state: "OPEN",
-          url: "https://github.com/test/repo/pull/42",
-          headRefName: "feature/test",
-          baseRefName: "main",
+          state: "open",
+          merged_at: null,
+          html_url: "https://github.com/test/repo/pull/42",
+          head: { ref: "feature/test" },
+          base: { ref: "main" },
           body: "PR body",
         },
       ]);
@@ -156,7 +157,7 @@ describe("API integration", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.diff).toContain("diff --git");
-    expect(data.diff).toContain("newModule");
+    expect(data.diff).toContain("addedModule");
   });
 
   test("GET /api/diff/auto returns auto-detected diff", async () => {

--- a/server/__tests__/poll-github.test.ts
+++ b/server/__tests__/poll-github.test.ts
@@ -11,6 +11,19 @@ function validHeaders(): Record<string, string> {
   return { host: `127.0.0.1:${PORT}` };
 }
 
+// REST API format (gh api repos/.../pulls)
+const REST_PR_DATA = {
+  number: 42,
+  title: "Test PR",
+  state: "open",
+  merged_at: null,
+  html_url: "https://github.com/test/repo/pull/42",
+  head: { ref: "feature/test" },
+  base: { ref: "main" },
+  body: "PR body",
+};
+
+// Expected normalized format after conversion
 const PR_DATA = {
   number: 42,
   title: "Test PR",
@@ -60,9 +73,9 @@ describe("pollGitHub cache behavior", () => {
     let shouldFail = false;
     const ghRunner: CommandRunner = async (cmd) => {
       const key = cmd.join(" ");
-      if (key.includes("gh pr list")) {
+      if (key.includes("gh api repos/") && key.includes("/pulls") && !key.includes("reviews")) {
         if (shouldFail) throw new Error("HTTP 500");
-        return JSON.stringify([PR_DATA]);
+        return JSON.stringify([REST_PR_DATA]);
       }
       if (key.includes("gh repo view"))
         return JSON.stringify({ owner: { login: "test" }, name: "repo" });
@@ -102,8 +115,8 @@ describe("pollGitHub cache behavior", () => {
     let hasPR = true;
     const ghRunner: CommandRunner = async (cmd) => {
       const key = cmd.join(" ");
-      if (key.includes("gh pr list")) {
-        return hasPR ? JSON.stringify([PR_DATA]) : JSON.stringify([]);
+      if (key.includes("gh api repos/") && key.includes("/pulls") && !key.includes("reviews")) {
+        return hasPR ? JSON.stringify([REST_PR_DATA]) : JSON.stringify([]);
       }
       if (key.includes("gh repo view"))
         return JSON.stringify({ owner: { login: "test" }, name: "repo" });

--- a/server/app.ts
+++ b/server/app.ts
@@ -180,9 +180,9 @@ export function createAppConfig(deps: AppDeps) {
 
   function startPolling() {
     if (pollTimer) return;
-    // Fetch immediately, then poll every 10s
+    // Fetch immediately, then poll every 60s
     pollGitHub();
-    pollTimer = setInterval(pollGitHub, 10000);
+    pollTimer = setInterval(pollGitHub, 60_000);
   }
 
   function stopPolling() {

--- a/server/github.ts
+++ b/server/github.ts
@@ -31,35 +31,71 @@ type CICheck = {
   url: string;
 };
 
+type RestPR = {
+  number: number;
+  title: string;
+  state: string;
+  merged_at: string | null;
+  html_url: string;
+  head: { ref: string };
+  base: { ref: string };
+  body: string | null;
+};
+
 export function createGitHubService(run: CommandRunner, cwd: string) {
   const gh = (args: string[]) => run(["gh", ...args], { cwd });
 
+  // Cache owner/repo — won't change during a session
+  let cachedOwnerRepo: { owner: string; repo: string } | null = null;
+  async function getOwnerRepo(): Promise<{ owner: string; repo: string }> {
+    if (cachedOwnerRepo) return cachedOwnerRepo;
+    const raw = await gh(["repo", "view", "--json", "owner,name"]);
+    const data = JSON.parse(raw) as { owner: { login: string }; name: string };
+    cachedOwnerRepo = { owner: data.owner.login, repo: data.name };
+    return cachedOwnerRepo;
+  }
+
   return {
-    // Use `gh pr list` instead of `gh pr view` to distinguish "no PR" from API errors.
-    // `gh pr view` returns exit code 1 for both cases, making them indistinguishable.
-    // `gh pr list` returns exit code 0 with empty array when no PR exists,
-    // and exit code 1 only on real API errors (network, auth).
-    // ref: https://github.com/cli/cli — `gh pr view` vs `gh pr list` exit code behavior
+    // Use REST API with --cache for conditional requests (ETag/304).
+    // 304 responses don't count against GitHub's rate limit.
+    // REST `gh api` returns exit code 0 with empty array when no PR exists,
+    // and non-zero on real API errors, preserving the same error semantics
+    // as the previous `gh pr list` approach.
     async getCurrentPR(branch: string): Promise<PRInfo | null> {
+      const { owner, repo } = await getOwnerRepo();
       const raw = await gh([
-        "pr",
-        "list",
-        "--head",
-        branch,
-        "--state",
-        "all",
-        "--json",
-        "number,title,state,url,headRefName,baseRefName,body",
-        "--limit",
-        "1",
+        "api",
+        `repos/${owner}/${repo}/pulls`,
+        "--cache",
+        "30s",
+        "-f",
+        `head=${owner}:${branch}`,
+        "-f",
+        "state=all",
+        "-f",
+        "per_page=1",
       ]);
-      const results: PRInfo[] = JSON.parse(raw);
-      return results.length > 0 ? (results[0] ?? null) : null;
+      const results: RestPR[] = JSON.parse(raw);
+      if (results.length === 0) return null;
+      const pr = results[0];
+      if (!pr) return null;
+      // REST API uses lowercase state without "merged" — derive from merged_at
+      const state = pr.merged_at ? "MERGED" : pr.state === "closed" ? "CLOSED" : "OPEN";
+      return {
+        number: pr.number,
+        title: pr.title,
+        state,
+        url: pr.html_url,
+        headRefName: pr.head.ref,
+        baseRefName: pr.base.ref,
+        body: pr.body ?? "",
+      };
     },
 
     async getPRComments(prNumber: number): Promise<PRComment[]> {
-      const query = `query($number: Int!) {
-        repository(owner: "{owner}", name: "{repo}") {
+      const { owner, repo } = await getOwnerRepo();
+      const query = `query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
           pullRequest(number: $number) {
             reviewThreads(first: 100) {
               nodes {
@@ -81,16 +117,16 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
           }
         }
       }`;
-      // Resolve {owner}/{repo} via gh repo view
-      const repoRaw = await gh(["repo", "view", "--json", "owner,name"]);
-      const repo = JSON.parse(repoRaw) as { owner: { login: string }; name: string };
-      const resolvedQuery = query.replace("{owner}", repo.owner.login).replace("{repo}", repo.name);
 
       const raw = await gh([
         "api",
         "graphql",
         "-f",
-        `query=${resolvedQuery}`,
+        `query=${query}`,
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `repo=${repo}`,
         "-F",
         `number=${prNumber}`,
       ]);
@@ -159,8 +195,7 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
     },
 
     async getCIChecks({ prNumber }: { prNumber: number }): Promise<CICheck[]> {
-      const repoRaw = await gh(["repo", "view", "--json", "owner,name"]);
-      const repo = JSON.parse(repoRaw) as { owner: { login: string }; name: string };
+      const { owner, repo } = await getOwnerRepo();
       const query = `query($owner: String!, $name: String!, $number: Int!) {
         repository(owner: $owner, name: $name) {
           pullRequest(number: $number) {
@@ -191,9 +226,9 @@ export function createGitHubService(run: CommandRunner, cwd: string) {
         "-f",
         `query=${query}`,
         "-F",
-        `owner=${repo.owner.login}`,
+        `owner=${owner}`,
         "-F",
-        `name=${repo.name}`,
+        `name=${repo}`,
         "-F",
         `number=${prNumber}`,
       ]);

--- a/server/plan.ts
+++ b/server/plan.ts
@@ -9,10 +9,7 @@ function cwdToProjectKey(cwd: string): string {
   return cwd.replace(/[/.]/g, "-");
 }
 
-async function findJsonlsByMtime(
-  projectDir: string,
-  limit = 5,
-): Promise<string[]> {
+async function findJsonlsByMtime(projectDir: string, limit = 5): Promise<string[]> {
   const glob = new Bun.Glob("*.jsonl");
   const entries: { path: string; mtime: number }[] = [];
 

--- a/src/components/DiffFile.tsx
+++ b/src/components/DiffFile.tsx
@@ -66,7 +66,13 @@ type RenderItem = FlatItem | FlatPRComment | FlatCommentForm | FlatPendingCommen
 
 type Props = {
   file: DiffFileType;
-  onComment?: (file: string, startLine: number, endLine: number, comment: string, mode: CommentMode) => void;
+  onComment?: (
+    file: string,
+    startLine: number,
+    endLine: number,
+    comment: string,
+    mode: CommentMode,
+  ) => void;
   prComments?: PRCommentData[];
   pendingComments?: PendingCommentData[];
 };
@@ -244,15 +250,27 @@ export function DiffFile({ file, onComment, prComments = [], pendingComments = [
         }
         if (showComment && selMax !== null && item.index === selMax) {
           if (selectedLineRange) {
-            items.push({ type: "copy-tooltip", file: file.newPath, startLine: selectedLineRange[0], endLine: selectedLineRange[1] });
+            items.push({
+              type: "copy-tooltip",
+              file: file.newPath,
+              startLine: selectedLineRange[0],
+              endLine: selectedLineRange[1],
+            });
           }
           items.push({ type: "comment-form" });
         }
       }
     }
     return items;
-  }, [flatItems, commentsByLine, pendingByLine, showComment, selMax, selectedLineRange, file.newPath]);
-
+  }, [
+    flatItems,
+    commentsByLine,
+    pendingByLine,
+    showComment,
+    selMax,
+    selectedLineRange,
+    file.newPath,
+  ]);
 
   const handleMouseDown = useCallback(
     (index: number) => {
@@ -289,7 +307,6 @@ export function DiffFile({ file, onComment, prComments = [], pendingComments = [
     setSelEnd(null);
     setShowComment(false);
   }, []);
-
 
   const handleSubmitComment = useCallback(
     (comment: string, mode: CommentMode) => {
@@ -409,7 +426,10 @@ export function DiffFile({ file, onComment, prComments = [], pendingComments = [
       }
 
       if (item.type === "copy-tooltip") {
-        const range = item.startLine === item.endLine ? `${item.startLine}` : `${item.startLine}-${item.endLine}`;
+        const range =
+          item.startLine === item.endLine
+            ? `${item.startLine}`
+            : `${item.startLine}-${item.endLine}`;
         const ref = `${item.file}:${range}`;
         return (
           <tr>
@@ -433,10 +453,7 @@ export function DiffFile({ file, onComment, prComments = [], pendingComments = [
         return (
           <tr>
             <td colSpan={4} className="p-2 bg-gray-900">
-              <CommentForm
-                onSubmit={handleSubmitComment}
-                onCancel={handleCancelComment}
-              />
+              <CommentForm onSubmit={handleSubmitComment} onCancel={handleCancelComment} />
             </td>
           </tr>
         );
@@ -544,13 +561,16 @@ export function DiffFile({ file, onComment, prComments = [], pendingComments = [
         </div>
       )}
       {!collapsed && (
-        <div className="border-x border-b border-[#30363d] rounded-b-md overflow-hidden" style={{ contentVisibility: "auto", containIntrinsicSize: "auto 500px" } as React.CSSProperties}>
+        <div
+          className="border-x border-b border-[#30363d] rounded-b-md overflow-hidden"
+          style={
+            { contentVisibility: "auto", containIntrinsicSize: "auto 500px" } as React.CSSProperties
+          }
+        >
           <table className={`w-full border-collapse ${file.isNew ? "bg-[#12261e]" : ""}`}>
             <tbody>
               {renderItems.map((item, i) => (
-                <React.Fragment key={renderItemKey(item, i)}>
-                  {renderRow(item)}
-                </React.Fragment>
+                <React.Fragment key={renderItemKey(item, i)}>{renderRow(item)}</React.Fragment>
               ))}
             </tbody>
           </table>

--- a/src/components/DiffLine.tsx
+++ b/src/components/DiffLine.tsx
@@ -63,7 +63,11 @@ export function DiffLine({
   // Review mode: neutral colors (no diff background tinting)
   // New files: use green-tinted gutter to match the file background
   const bg = reviewMode ? "" : LINE_BG[line.type];
-  const gutterBg = reviewMode ? (isNewFile ? "bg-[#1a3329]" : "bg-[#161b22]") : GUTTER_BG[line.type];
+  const gutterBg = reviewMode
+    ? isNewFile
+      ? "bg-[#1a3329]"
+      : "bg-[#161b22]"
+    : GUTTER_BG[line.type];
   const gutterText = reviewMode ? "text-[#848d97]" : GUTTER_TEXT[line.type];
   const prefixColor = reviewMode ? "text-transparent" : PREFIX_COLOR[line.type];
   const textColor = hasTokens ? "" : reviewMode ? "text-[#adbac7]" : LINE_TEXT[line.type];

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -48,7 +48,13 @@ export function DiffView({
   const { addToReview, pending } = useReviewQueue();
 
   const handleComment = useCallback(
-    async (file: string, startLine: number, endLine: number, comment: string, mode: CommentMode) => {
+    async (
+      file: string,
+      startLine: number,
+      endLine: number,
+      comment: string,
+      mode: CommentMode,
+    ) => {
       if (mode === "review") {
         addToReview({ file, startLine, endLine, comment });
       } else {
@@ -119,15 +125,17 @@ export function DiffView({
           </span>
         </div>
       )}
-      {diff.filter((file) => !file.generated).map((file, idx) => (
-        <DiffFile
-          key={`${file.newPath}-${idx}`}
-          file={file}
-          onComment={hasTerminal ? handleComment : undefined}
-          prComments={prComments.filter((c) => c.path === file.newPath)}
-          pendingComments={pending.filter((c) => c.file === file.newPath)}
-        />
-      ))}
+      {diff
+        .filter((file) => !file.generated)
+        .map((file, idx) => (
+          <DiffFile
+            key={`${file.newPath}-${idx}`}
+            file={file}
+            onComment={hasTerminal ? handleComment : undefined}
+            prComments={prComments.filter((c) => c.path === file.newPath)}
+            pendingComments={pending.filter((c) => c.file === file.newPath)}
+          />
+        ))}
     </div>
   );
 }

--- a/src/components/PendingComment.tsx
+++ b/src/components/PendingComment.tsx
@@ -72,10 +72,7 @@ export function PendingComment({ comment, onUpdate, onDelete }: PendingCommentPr
         >
           Edit
         </button>
-        <button
-          onClick={onDelete}
-          className="text-xs text-[#848d97] hover:text-[#f85149] px-1"
-        >
+        <button onClick={onDelete} className="text-xs text-[#848d97] hover:text-[#f85149] px-1">
           Delete
         </button>
       </div>

--- a/src/hooks/useReviewQueue.tsx
+++ b/src/hooks/useReviewQueue.tsx
@@ -56,7 +56,15 @@ export function ReviewQueueProvider({ children }: { children: React.ReactNode })
 
   return (
     <ReviewQueueContext.Provider
-      value={{ pending, addToReview, updatePending, removePending, clearQueue, submitReview, submitting }}
+      value={{
+        pending,
+        addToReview,
+        updatePending,
+        removePending,
+        clearQueue,
+        submitReview,
+        submitting,
+      }}
     >
       {children}
     </ReviewQueueContext.Provider>


### PR DESCRIPTION
## Summary

Replaces `gh pr list` with `gh api repos/.../pulls --cache 30s` to leverage GitHub's ETag-based conditional requests — 304 Not Modified responses don't count against the rate limit. Owner/repo resolution is now cached per-service instance to avoid redundant `gh repo view` calls. Poll interval is increased from 10s to 60s to further reduce API pressure.

## Changes

- `server/github.ts`: Switch `getCurrentPR` to use REST API endpoint `repos/{owner}/{repo}/pulls` with `--cache 30s`. Add `getOwnerRepo()` helper with per-instance caching. Normalize REST response (lowercase `state`, `merged_at`, `html_url`, `head.ref`, `base.ref`) to the internal `PRInfo` type. Share cached owner/repo in `getPRComments` and `getCIChecks` (removes two extra `gh repo view` calls).
- `server/app.ts`: Increase poll interval from 10,000ms to 60,000ms.
- `server/__tests__/github.test.ts`: Update tests for new REST API format; add MERGED/CLOSED state normalization tests and owner/repo caching assertion.
- `server/__tests__/integration.test.ts`, `server/__tests__/poll-github.test.ts`: Update fake runners to return REST API response shape. Fix secretlint false-positive in fake diff string.

## Breaking Changes

None. The `PRInfo` type contract is unchanged.

## Test Plan

- Run `bun test src server` — all tests pass
- The poll interval change and REST API migration are transparent to the frontend; no UI changes required
- Manual: open cmux-hub on a branch with an open PR and verify PR status still appears in the toolbar
