### PR TITLE
fix(plugin): reap per-session cmux-hub server on SessionEnd

### DIFF
--- a/cmux-hub-plugin/README.md
+++ b/cmux-hub-plugin/README.md
@@ -47,6 +47,10 @@ This is useful when developing cmux-hub itself or running a custom dev server. Y
 
 Use the `/cmux-hub:start` skill to manually start cmux-hub in the current project. This works even when auto-start is disabled via `CMUX_HUB_NO_AUTOSTART=1`.
 
+## Cleanup
+
+A `SessionEnd` hook terminates the per-session `cmux-hub` server when the Claude Code session exits. Each session's PID is tracked at `${XDG_STATE_HOME:-~/.local/state}/cmux-hub/sessions/<session_id>.pid` so cleanup targets only this session's server, leaving concurrent surfaces alone.
+
 ## Prerequisites
 
 cmux-hub connects to the cmux Unix socket. See [Prerequisites](https://github.com/azu/cmux-hub#prerequisites) for socket mode configuration.

--- a/cmux-hub-plugin/hooks/hooks.json
+++ b/cmux-hub-plugin/hooks/hooks.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/stop.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/cmux-hub-plugin/scripts/start.sh
+++ b/cmux-hub-plugin/scripts/start.sh
@@ -17,6 +17,31 @@ if [ -z "${CMUX_SURFACE_ID:-}" ]; then
   exit 0
 fi
 
+# Read session_id from hook stdin (Claude Code passes JSON on stdin to hooks).
+# Skip when stdin is a TTY so the script is still runnable manually.
+HOOK_INPUT=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat)"
+fi
+SESSION_ID=""
+if [ -n "$HOOK_INPUT" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    SESSION_ID="$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+  elif command -v python3 >/dev/null 2>&1; then
+    SESSION_ID="$(printf '%s' "$HOOK_INPUT" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("session_id",""))
+except Exception:
+    pass' 2>/dev/null || true)"
+  fi
+fi
+
+# Restrict session_id to a safe character class before using it as a filename,
+# to prevent path traversal if a future caller passes an unexpected value.
+case "$SESSION_ID" in
+  ''|*[!A-Za-z0-9_-]*) SESSION_ID="" ;;
+esac
+
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 USER_ACTIONS="${HOME}/.claude/cmux-hub.json"
 
@@ -34,14 +59,26 @@ else
 fi
 
 # Setup logging per project
-LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/cmux-hub"
-mkdir -p "$LOG_DIR"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/cmux-hub"
+mkdir -p "$STATE_DIR"
 PROJECT_NAME="$(basename "$PWD")"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
-LOG_FILE="${LOG_DIR}/${PROJECT_NAME}-${TIMESTAMP}.log"
+LOG_FILE="${STATE_DIR}/${PROJECT_NAME}-${TIMESTAMP}.log"
 
 # Start cmux-hub in background with logging
 CMUX_HUB="${HOME}/.local/bin/cmux-hub"
 echo "[${TIMESTAMP}] Starting cmux-hub (pwd: $PWD)" >> "$LOG_FILE"
 "$CMUX_HUB" --actions "$ACTIONS" >> "$LOG_FILE" 2>&1 &
+SERVER_PID=$!
 disown
+
+# Track PID per session so SessionEnd can reap exactly this session's server
+# without disturbing concurrent surfaces.
+if [ -n "$SESSION_ID" ]; then
+  SESSIONS_DIR="${STATE_DIR}/sessions"
+  mkdir -p "$SESSIONS_DIR"
+  PID_FILE="${SESSIONS_DIR}/${SESSION_ID}.pid"
+  TMP_PID_FILE="${PID_FILE}.tmp.$$"
+  printf '%s\n' "$SERVER_PID" > "$TMP_PID_FILE"
+  mv "$TMP_PID_FILE" "$PID_FILE"
+fi

--- a/cmux-hub-plugin/scripts/stop.sh
+++ b/cmux-hub-plugin/scripts/stop.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# Mirror start.sh skip-conditions: if start.sh skipped, there is no pidfile to read.
+if [ "${CMUX_HUB_NO_AUTOSTART:-}" = "1" ]; then
+  exit 0
+fi
+if [ "${CLAUDE_CODE_ENTRYPOINT:-}" = "claude-desktop" ]; then
+  exit 0
+fi
+if [ -z "${CMUX_SURFACE_ID:-}" ]; then
+  exit 0
+fi
+
+# Read session_id from hook stdin (Claude Code passes JSON on stdin to hooks).
+HOOK_INPUT=""
+if [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat)"
+fi
+SESSION_ID=""
+if [ -n "$HOOK_INPUT" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    SESSION_ID="$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+  elif command -v python3 >/dev/null 2>&1; then
+    SESSION_ID="$(printf '%s' "$HOOK_INPUT" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("session_id",""))
+except Exception:
+    pass' 2>/dev/null || true)"
+  fi
+fi
+
+# Restrict session_id to a safe character class before using it as a filename,
+# to prevent path traversal if a future caller passes an unexpected value.
+case "$SESSION_ID" in
+  ''|*[!A-Za-z0-9_-]*) SESSION_ID="" ;;
+esac
+
+# Without a session_id we cannot identify which server to stop, and indiscriminate
+# pkill would kill servers owned by concurrent sessions.
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/cmux-hub"
+PID_FILE="${STATE_DIR}/sessions/${SESSION_ID}.pid"
+
+# Tolerate missing pidfile (start skipped, or already cleaned up).
+if [ ! -f "$PID_FILE" ]; then
+  exit 0
+fi
+
+PID="$(cat "$PID_FILE" 2>/dev/null || true)"
+rm -f "$PID_FILE"
+
+# Tolerate empty/non-numeric pidfile contents.
+case "$PID" in
+  ''|*[!0-9]*) exit 0 ;;
+esac
+
+# Tolerate stale pidfile (process already exited).
+if ! kill -0 "$PID" 2>/dev/null; then
+  exit 0
+fi
+
+# Graceful TERM, then KILL after ~500ms to bound the hook's latency.
+kill -TERM "$PID" 2>/dev/null || true
+for _ in 1 2 3 4 5; do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 0.1
+done
+kill -KILL "$PID" 2>/dev/null || true
+exit 0


### PR DESCRIPTION
Fixes #17.

## Problem

The plugin's `SessionStart` hook spawns `cmux-hub` with `& disown` (`cmux-hub-plugin/scripts/start.sh`), but `cmux-hub-plugin/hooks/hooks.json` registers no `SessionEnd` hook. Each new Claude Code session starts another server on a fresh port; nothing tears any of them down. Reporter observed 145 leaked `cmux-hub` listeners on a single machine.

## Fix

- `start.sh`: read the hook's stdin JSON to get `session_id` (`jq` preferred, `python3` fallback), validate its character class against `[A-Za-z0-9_-]`, capture `$!`, and atomically write `${XDG_STATE_HOME:-~/.local/state}/cmux-hub/sessions/<session_id>.pid` (write to `.tmp.$$` then `mv`).
- New `stop.sh`: reads the same `session_id` (with the same validation), looks up the pidfile, sends `SIGTERM`, polls 5×100ms, then `SIGKILL`. Removes the pidfile.
- `hooks.json`: register `SessionEnd` with no matcher so it fires on every reason (`clear`, `resume`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, `other`).
- `README.md`: short Cleanup section documenting the new behavior and pidfile path.

Per-session keying ensures cleanup targets only this session's process, leaving concurrent cmux surfaces alone. The existing skip-conditions (`CMUX_HUB_NO_AUTOSTART=1`, missing `CMUX_SURFACE_ID`, `claude-desktop` entrypoint) are honored by both scripts. Stale/empty/missing pidfiles and absent stdin (e.g. running `start.sh` manually from a TTY) are tolerated; neither script fails the hook.

## Out of scope

- The manual `/cmux-hub:start` skill is unchanged: it has no `session_id`, runs outside the hook system, and remains the user's responsibility to stop.
- No version bump; that belongs to a release.

## Verification

Ran a harness piping synthetic hook JSON into `start.sh`/`stop.sh` against a stubbed `cmux-hub` binary in an isolated `HOME`/`XDG_STATE_HOME`:

1. start writes pidfile, process is alive
2. stop removes pidfile, kills process
3. stale pidfile (PID 99999) → stop exits 0 cleanly, pidfile removed
4. two concurrent sessions; stopping one leaves the other running
5a. `CMUX_HUB_NO_AUTOSTART=1` → both scripts no-op (no state files written)
5b. missing `CMUX_SURFACE_ID` → both scripts no-op
6. stop with no prior pidfile → exits 0
7. path-traversal `session_id` (`"../pwned"`) → rejected, no pidfile written

All scenarios pass.

CI is unaffected: this changes only bash under `cmux-hub-plugin/scripts/` plus `hooks.json` and a README paragraph; the Bun lint/typecheck/unit/e2e jobs only touch the TypeScript app.